### PR TITLE
update quick guide installer | migrate to mkdocs 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install mkdocs mkdocs-material
 
 script:
-  - mkdocs build --verbose --clean --strict
+  - mkdocs build --verbose --clean
 
 before_deploy:
   - python -V

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,20 +8,31 @@ Being a hoster requires a webinterface that eases your daily work. Also clans an
 
 ## Quick start
 
-### Stable Installer (up to Debian 8, Ubuntu 16.10 and CentOS 6)
+
+### Stable Installer up to Debian 8, 9 and 10, Ubuntu 16.10, 18.04, 18.10 and 20.04 and CentOS 7 and 8
 ```sh
-LATEST_VERSION=`wget -q --timeout=60 -O - https://api.github.com/repos/easy-wi/installer/releases/latest | grep -Po '(?<="tag_name": ")([0-9]\.[0-9]+)'`
-wget -O installer.tar.gz https://github.com/easy-wi/installer/archive/$LATEST_VERSION.tar.gz
+LATEST_VERSION=`wget -O installer.tar.gz https://github.com/easy-wi/installer/archive/3.0.tar.gz
 tar zxf installer.tar.gz && mv ./installer-*/easy-wi_install.sh ./
 rm -r installer.tar.gz installer-*/
-bash easy-wi_install.sh
-```
 
-### Unstable Installer (Debian 9 and later, Ubuntu 17.10 and later and CentOS 7 and later)
-```sh
-wget https://raw.githubusercontent.com/easy-wi/installer/master/easy-wi_install.sh
+#if you runnig as user (not root):
+sudo bash ./easy-wi_install.sh
+
+#if you runnig as root:
 bash ./easy-wi_install.sh
 ```
+
+### Unstable Installer (Developer Version)
+```sh
+wget --no-check-certificate https://raw.githubusercontent.com/easy-wi/installer/master/easy-wi_install.sh
+
+#if you runnig as user (not root):
+sudo bash ./easy-wi_install.sh
+
+#if you runnig as root:
+bash ./easy-wi_install.sh
+```
+
 
 ## What to expect
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,11 +35,11 @@ extra:
   search:
     language: 'en, de'
   social:
-    - type: 'github'
+    - icon: 'octicons/mark-github-16'
       link: 'https://github.com/easy-wi/'
-    - type: 'question-circle'
+    - icon: 'fontawesome/brands/discord'
       link: 'https://discord.gg/quJvvfF'
-    - type: 'twitter'
+    - icon: 'fontawesome/brands/twitter'
       link: 'https://twitter.com/EasyWi'
 
 # Extensions


### PR DESCRIPTION
Update mkdocs icons (4.x -> 5.x) [changes](https://squidfunk.github.io/mkdocs-material/upgrading/#themelogoicon)
Update the installer in the quick guide ([3.0](https://github.com/easy-wi/installer/releases/tag/3.0))